### PR TITLE
address missing surName issue

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # EMLeditor v0.1.0.7 "Work in progress"
 
+## 12 June 2023
+  * updated error messages in `get_author_list()` and `get_citation()` to be more informative, especially when surName is missing from the creator/individualName
+
 ## 21 April 2023
   * updated `set_datastore_doi()` so that it does not prompt to use `set_datastore_doi()` if there is no previous doi. Fixed readline prompt cursor on the wrong line. Now generates draft references with blank fields instead of place-holder strings (except for the title).
 

--- a/R/getEMLfunctions.R
+++ b/R/getEMLfunctions.R
@@ -281,6 +281,9 @@ get_author_list <- function(eml_object) {
         last_first <- toString(last_first)
       }
     }
+    if(is.null(last_first)){
+      cat("There is something wrong with the creators field. Please check that you have a supplied a givenName and surName for each creator.")
+    }
   }
 }
 

--- a/R/getEMLfunctions.R
+++ b/R/getEMLfunctions.R
@@ -193,7 +193,7 @@ get_citation <- function(eml_object) {
     warning("No doi specified. Please use set_doi to add a DOI.")
   }
   if (is.null(author_list)) {
-    warning("No authors listed. Please add authors as \"creator\" in EMLassemlbyline.")
+    warning("No creators detected. Please add at least one \"creator\" in EMLassemlbyline with a valid givenName and surName.")
   }
   if (is.null(title)) {
     warning("No title specified.")


### PR DESCRIPTION
updated error messages in get_citation() and get_author_list() to give more informative error messages when the surName field is missing. 

Partially addresses https://github.com/nationalparkservice/DPchecker/issues/90
