### PR TITLE
Added missing close paren to chunk in creation guide

### DIFF
--- a/vignettes/a02_EML_creation_script.Rmd
+++ b/vignettes/a02_EML_creation_script.Rmd
@@ -44,7 +44,7 @@ options(download.file.method="wininet")
 ```
 ```{r package_install, eval=FALSE}
 #install packages
-install.packages(c("devtools", "tidyverse")
+install.packages(c("devtools", "tidyverse"))
 devtools::install_github("nationalparkservice/NPSdataverse")
 ```
 ```{r load_packages, eval=FALSE}


### PR DESCRIPTION
After reviewing the file, I noticed that the package installation chunk was missing a closing paren, throwing `unexpected symbol` errors.