### PR TITLE
Fixed syntax error

### DIFF
--- a/inst/rmarkdown/templates/editable_eml_creation_workflow/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/editable_eml_creation_workflow/skeleton/skeleton.Rmd
@@ -24,7 +24,7 @@ options(download.file.method="wininet")
 ```
 ```{r package_install, eval=FALSE}
 #install packages
-install.packages(c("devtools", "tidyverse")
+install.packages(c("devtools", "tidyverse"))
 devtools::install_github("nationalparkservice/NPSdataverse")
 ```
 ```{r load_packages}


### PR DESCRIPTION
Hey there; back with yet another mundane pull request. It's the same missing closing paren from before ( #120 ), just in a different file

I should've caught this the first time around; I only just realized that this skeleton file was the one you were walking us through a few days ago. I spotted the error on RStudio at first, then just found and PR'd the first file I found with the error assuming it was the same file I was looking at. I didn't realize there was _another_ file with the same issue. Sorry about that!