### PR TITLE
Make EMLscript more useable

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
 # EMLeditor v0.1.7 (under development)
+## 2024-11-04
+  * Fix documentation in EMLscript code chunk that can make it difficult/confusing to enter user input after running the `upload_data_package` function.
 ## 2024-10-23
   * updates and fixes to documentation including spelling, grammar, and clarity
   * remove non-exported functions from documentation

--- a/docs/news/index.html
+++ b/docs/news/index.html
@@ -72,8 +72,9 @@
     <div class="section level2">
 <h2 class="page-header" data-toc-text="0.1.7" id="emleditor-v017-under-development">EMLeditor v0.1.7 (under development)<a class="anchor" aria-label="anchor" href="#emleditor-v017-under-development"></a></h2>
 <div class="section level3">
-<h3 id="id_2024-0-1-7">2024-10-23<a class="anchor" aria-label="anchor" href="#id_2024-0-1-7"></a></h3>
-<ul><li>updates and fixes to documentation including spelling, grammar, and clarity</li>
+<h3 id="id_2024-0-1-7">2024-11-04<a class="anchor" aria-label="anchor" href="#id_2024-0-1-7"></a></h3>
+<ul><li>Fix documentation in EMLscript code chunk that can make it difficult/confusing to enter user input after running the <code>upload_data_package</code> function. ## 2024-10-23</li>
+<li>updates and fixes to documentation including spelling, grammar, and clarity</li>
 <li>remove non-exported functions from documentation</li>
 <li>move several packages from Imports to Suggests (ISOcodes, sf, gdata)</li>
 </ul></div>

--- a/docs/pkgdown.yml
+++ b/docs/pkgdown.yml
@@ -7,4 +7,4 @@ articles:
   a03_Template_edits: a03_Template_edits.html
   a04_Editing_fixing_eml: a04_Editing_fixing_eml.html
   a05_advanced_functionality: a05_advanced_functionality.html
-last_built: 2024-10-23T14:29Z
+last_built: 2024-11-04T20:37Z

--- a/inst/rmarkdown/templates/editable_eml_creation_workflow/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/editable_eml_creation_workflow/skeleton/skeleton.Rmd
@@ -357,10 +357,11 @@ DPchecker::run_congruence_checks()
 If everything checked out, you should be ready to upload your data package! We recommend using `upload_data_package()` to accomplish this. The function automatically checks your DOI and uploads to the correct reference on DataStore. All of your files for the data package need to be in the same folder, there can be only one .xml file (ending in "_metadata.xml") and all the other files should be data files in .csv format. Each individual file should be < 32Mb.  If you have files > 32Mb, you will need to upload them manually using the web interface on DataStore. 
 ```{r upload}
 # this assumes your data package is in the current working directory
-EMLeditor::upload_data_package()
 
 # If your data package is somewhere else, specify that:
 #upload_data_package("C:/Users/<yourusername>/Documents/my_data_package)
+
+EMLeditor::upload_data_package()
 ```
 
 From within DataStore you should be able to extract all the information from the metadata file to populate the relevant DataStore fields. In the upper right, select "Edit" from the drop down menu. Then click on the "Files and Links" tab. On the left side of the files list, select the radio button corresponding to your metadata. Then click the "Extract Metadata" button from the top right of box with the files listed in it. 


### PR DESCRIPTION
When sending whole code chunks to the console, code that requires user input but is followed by comments or commented out code can prevent that input from being taken by the function.