### PR TITLE
remove dependency on arcticdatautils

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,6 @@ Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2
 Remotes: 
-    NCEAS/arcticdatautils,
     nationalparkservice/QCkit
 Imports: 
     httr,
@@ -44,7 +43,6 @@ Imports:
     mockr,
     rlang,
 Suggests:
-    arcticdatautils,
     stargazer,
     knitr,
     rmarkdown,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,7 @@
 # EMLeditor v1.0.1 (under development)
+## 2025-04-14
+  * remove all calls to arcticdatautils package; remove arcticdatautils from suggests and remotes.
+  
 ## 2025-04-11
   * add `get_eml_simple` function and associated unit test.
   

--- a/R/editEMLfunctions.R
+++ b/R/editEMLfunctions.R
@@ -1108,7 +1108,7 @@ set_lit <- function(eml_object, bibtex_file, force = FALSE, NPS = TRUE) {
   }
   # interactive route:
   if (force == FALSE) {
-    lit <- arcticdatautils::eml_get_simple(eml_object, "literatureCited")
+    lit <- get_eml_simple(eml_object, "literatureCited")
     if (is.null(lit)) {
       eml_object$dataset$literatureCited$bibtex <- bibtex_citation
     } else {

--- a/R/getEMLfunctions.R
+++ b/R/getEMLfunctions.R
@@ -34,7 +34,7 @@ get_eml_simple <- function(eml_object, eml_element){
 #' get_begin_date(eml_object)
 #' }
 get_begin_date <- function(eml_object) {
-  begin <- arcticdatautils::eml_get_simple(eml_object, "beginDate")
+  begin <- get_eml_simple(eml_object, "beginDate")
   if (is.null(begin)) {
     warning("Your metadata lacks a begining date.")
     begin <- NA # to do: test whether NA needs quotes for write.README.
@@ -59,7 +59,7 @@ get_begin_date <- function(eml_object) {
 #' get_end_date(eml_object)
 #' }
 get_end_date <- function(eml_object) {
-  end <- arcticdatautils::eml_get_simple(eml_object, "endDate")
+  end <- get_eml_simple(eml_object, "endDate")
   if (is.null(end)) {
     warning("Your metadata lacks an ending date.")
     end <- NA # to do: test whether NA needs quotes for write.README.
@@ -177,7 +177,7 @@ get_additional_info <- function(eml_object) {
 #' get_title(eml_object)
 #' }
 get_title <- function(eml_object) {
-  doc <- arcticdatautils::eml_get_simple(eml_object, "title")[1]
+  doc <- get_eml_simple(eml_object, "title")[1]
   if (is.null(doc)) {
     doc <- NA
   }
@@ -239,7 +239,7 @@ get_citation <- function(eml_object) {
 
   title <- get_title(eml_object)
 
-  pub_date <- arcticdatautils::eml_get_simple(eml_object, "pubDate")
+  pub_date <- get_eml_simple(eml_object, "pubDate")
   pub_date <- lubridate::parse_date_time(pub_date, orders = "Y-m-d")
   pub_year <- lubridate::year(pub_date)
 
@@ -407,7 +407,7 @@ get_doi <- function(eml_object) {
 #' get_content_units(eml_object)
 #' }
 get_content_units <- function(eml_object) {
-  units <- arcticdatautils::eml_get_simple(eml_object, "geographicDescription")
+  units <- get_eml_simple(eml_object, "geographicDescription")
   if (is.null(units)) {
     warning("No Park Unit Connections specified. Use the set_content_units() function to add Park Unit Connections.")
     punits <- NA # to do: test whether NA needs quotes for write.README.
@@ -456,7 +456,7 @@ get_content_units <- function(eml_object) {
 #' get_cui(eml_object)
 #' }
 get_cui_code <- function(eml_object) {
-  cui <- arcticdatautils::eml_get_simple(eml_object, "CUI")
+  cui <- get_eml_simple(eml_object, "CUI")
   if (is.null(cui)) {
     cat("No CUI specified. Use the set_cui() function to add a properly formatted CUI code.")
     cui <- "No CUI specified."
@@ -502,7 +502,7 @@ get_cui <- function(eml_object) {
   #add in deprecation
   lifecycle::deprecate_soft(when = "0.1.5", "set_cui()", "set_cui_dissem()")
 
-  cui <- arcticdatautils::eml_get_simple(eml_object, "CUI")
+  cui <- get_eml_simple(eml_object, "CUI")
   if (is.null(cui)) {
     cat("No CUI specified. Use the set_cui() function to add a properly formatted CUI code.")
     cui <- "No CUI specified."
@@ -626,14 +626,14 @@ get_cui_marking <- function(eml_object) {
 #' }
 get_file_info <- function(eml_object) {
   # get file names
-  file_name <- arcticdatautils::eml_get_simple(eml_object, "objectName")
+  file_name <- get_eml_simple(eml_object, "objectName")
 
   if (is.null(file_name)) {
     warning("You have not specified data file names, sizes, or descriptions. If you used EMLassemblyline, double check for any issues generated after running make_eml. Missing data and undefined units will often cause this problem.")
     print("NA")
   } else {
     # get file sizes (assumes in bytes)
-    file_size <- arcticdatautils::eml_get_simple(eml_object, "size")
+    file_size <- get_eml_simple(eml_object, "size")
     file_size <- suppressWarnings(as.numeric(file_size))
     file_byte <- unique(file_size)
     file_byte <- file_byte[!is.na(file_byte)]
@@ -641,8 +641,7 @@ get_file_info <- function(eml_object) {
                                      standard = "Unix") %>% paste0("B")
 
     # get file descriptions
-    file_descript <- arcticdatautils::eml_get_simple(eml_object,
-                                                     "entityDescription")
+    file_descript <- get_eml_simple(eml_object, "entityDescription")
 
     # generate dataframe for display:
     dat <- data.frame(file_name, readable, file_descript)
@@ -726,7 +725,7 @@ get_drr_title <- function(eml_object) {
 #' get_lit(eml_object)
 #' }
 get_lit <- function(eml_object) {
-  lit <- arcticdatautils::eml_get_simple(eml_object, "literatureCited")
+  lit <- get_eml_simple(eml_object, "literatureCited")
   return(lit)
 }
 
@@ -744,7 +743,7 @@ get_lit <- function(eml_object) {
 #' get_producing_units(eml_object)
 #' }
 get_producing_units <- function(eml_object) {
-  punit <- arcticdatautils::eml_get_simple(eml_object, "metadataProvider")
+  punit <- get_eml_simple(eml_object, "metadataProvider")
   return(punit)
 }
 

--- a/docs/news/index.html
+++ b/docs/news/index.html
@@ -43,38 +43,42 @@
     <div class="section level2">
 <h2 class="pkg-version" data-toc-text="1.0.1" id="emleditor-v101-under-development">EMLeditor v1.0.1 (under development)<a class="anchor" aria-label="anchor" href="#emleditor-v101-under-development"></a></h2>
 <div class="section level3">
-<h3 id="id_2025-1-0-1">2025-04-11<a class="anchor" aria-label="anchor" href="#id_2025-1-0-1"></a></h3>
+<h3 id="id_2025-1-0-1">2025-04-14<a class="anchor" aria-label="anchor" href="#id_2025-1-0-1"></a></h3>
+<ul><li>remove all calls to arcticdatautils package; remove arcticdatautils from suggests and remotes.</li>
+</ul></div>
+<div class="section level3">
+<h3 id="id_2025-1-0-1-1">2025-04-11<a class="anchor" aria-label="anchor" href="#id_2025-1-0-1-1"></a></h3>
 <ul><li>add <code>get_eml_simple</code> function and associated unit test.</li>
 </ul></div>
 <div class="section level3">
-<h3 id="id_2025-1-0-1-1">2025-04-09<a class="anchor" aria-label="anchor" href="#id_2025-1-0-1-1"></a></h3>
+<h3 id="id_2025-1-0-1-2">2025-04-09<a class="anchor" aria-label="anchor" href="#id_2025-1-0-1-2"></a></h3>
 <ul><li>update <code>set_data_urls</code> to set dataset urls in addition to dataTable urls. <code>set_data_urls</code> now adds a function = “information” tag to urls because they do not lead to direct file download links. It will overwrite all function = “download” tags added by ezEML.</li>
 <li>update <code>set_data_urls</code> unit tests; add test for function = “information”.</li>
 <li>update <code>set_data_urls</code> to allow custom tags only when custom urls are also supplied. Added unit tests to cover new code.</li>
 </ul></div>
 <div class="section level3">
-<h3 id="id_2025-1-0-1-2">2025-03-25<a class="anchor" aria-label="anchor" href="#id_2025-1-0-1-2"></a></h3>
+<h3 id="id_2025-1-0-1-3">2025-03-25<a class="anchor" aria-label="anchor" href="#id_2025-1-0-1-3"></a></h3>
 <ul><li>fix bug that prevented <code>upload_data_package</code> from uploading some .csv files.</li>
 </ul></div>
 <div class="section level3">
-<h3 id="id_2025-1-0-1-3">2025-03-12<a class="anchor" aria-label="anchor" href="#id_2025-1-0-1-3"></a></h3>
+<h3 id="id_2025-1-0-1-4">2025-03-12<a class="anchor" aria-label="anchor" href="#id_2025-1-0-1-4"></a></h3>
 <ul><li>fix typos in skeleton.rmd and a02_EML_creation_script.Rmd</li>
 <li>remove redundant <code>check_eml</code> function and update associated documentation</li>
 <li>remove <code>DPchecker</code> as a dependency from DESCRIPTION</li>
 <li>Update to MIT license which is JOSS, NPS, and R compatible!</li>
 </ul></div>
 <div class="section level3">
-<h3 id="id_2025-1-0-1-4">2025-03-10<a class="anchor" aria-label="anchor" href="#id_2025-1-0-1-4"></a></h3>
+<h3 id="id_2025-1-0-1-5">2025-03-10<a class="anchor" aria-label="anchor" href="#id_2025-1-0-1-5"></a></h3>
 <ul><li>refactor upload_data_package to not depend on <code><a href="https://nationalparkservice.github.io/DPchecker/reference/load_metadata.html" class="external-link">DPchecker::load_metadata</a></code> ## 2025-03-10</li>
 <li>Updated license to OSI-approved “Zero-Clause BSD” in support of JOSS submission.</li>
 </ul></div>
 <div class="section level3">
-<h3 id="id_2025-1-0-1-5">2025-02-25<a class="anchor" aria-label="anchor" href="#id_2025-1-0-1-5"></a></h3>
+<h3 id="id_2025-1-0-1-6">2025-02-25<a class="anchor" aria-label="anchor" href="#id_2025-1-0-1-6"></a></h3>
 <ul><li>Update <code>CONTRIBUTING.md</code> file ## 2025-02-22</li>
 <li>Add <code>CONTRIBUTING.md</code> file</li>
 </ul></div>
 <div class="section level3">
-<h3 id="id_2025-1-0-1-6">2025-02-06<a class="anchor" aria-label="anchor" href="#id_2025-1-0-1-6"></a></h3>
+<h3 id="id_2025-1-0-1-7">2025-02-06<a class="anchor" aria-label="anchor" href="#id_2025-1-0-1-7"></a></h3>
 <ul><li>Bug fix in <code>set_int_rights</code> that was affecting CC0 licenses.</li>
 </ul></div>
 </div>

--- a/docs/pkgdown.yml
+++ b/docs/pkgdown.yml
@@ -7,7 +7,7 @@ articles:
   a03_Template_edits: a03_Template_edits.html
   a04_Editing_fixing_eml: a04_Editing_fixing_eml.html
   a05_advanced_functionality: a05_advanced_functionality.html
-last_built: 2025-04-11T22:09Z
+last_built: 2025-04-14T15:20Z
 urls:
   reference: https://nationalparkservice.github.io/EMLeditor/reference
   article: https://nationalparkservice.github.io/EMLeditor/articles

--- a/tests/testthat/test-editEMLfunctions.R
+++ b/tests/testthat/test-editEMLfunctions.R
@@ -87,7 +87,7 @@ test_that("set_doi does not replace doi when user says not to", {
 test_that("set_content_units works on valid eml", {
   new_units <- c("JOTR", "DEVA")
   new_meta <- set_content_units(BICY_EMLed_meta, new_units, force=TRUE)
-  geo_desc <- arcticdatautils::eml_get_simple(new_meta, "geographicDescription")
+  geo_desc <- get_eml_simple(new_meta, "geographicDescription")
   expect_true(all(c("NPS Content Unit Link: JOTR", "NPS Content Unit Link: DEVA") %in% geo_desc))
 })
 
@@ -95,7 +95,7 @@ test_that("set_content_units works with a single input", {
   # Try it with a single unit that is not a capital-P park
   new_units <- c("PARA")
   new_meta <- set_content_units(BICY_EMLed_meta, new_units, force=TRUE)
-  geo_desc <- arcticdatautils::eml_get_simple(new_meta, "geographicDescription")
+  geo_desc <- get_eml_simple(new_meta, "geographicDescription")
   expect_true("NPS Content Unit Link: PARA" %in% geo_desc)
 })
 
@@ -109,7 +109,7 @@ test_that("set_content_units retains input when told to", {
     new_meta2 <- set_content_units(new_meta,
                                    "YELL",
                                    force = FALSE)
-    geo_desc <- arcticdatautils::eml_get_simple(new_meta2, "geographicDescription")
+    geo_desc <- get_eml_simple(new_meta2, "geographicDescription")
     expect_false("NPS Content Unit Link: YELL" %in% geo_desc)
   })
 })
@@ -124,7 +124,7 @@ test_that("set_content_units adds input when told to", {
     new_meta2 <- set_content_units(new_meta,
                                    "YELL",
                                    force = FALSE)
-    geo_desc <- arcticdatautils::eml_get_simple(new_meta2, "geographicDescription")
+    geo_desc <- get_eml_simple(new_meta2, "geographicDescription")
     expect_true("NPS Content Unit Link: YELL" %in% geo_desc)
   })
 })
@@ -139,7 +139,7 @@ test_that("set_content_units replaces input when told to", {
     new_meta2 <- set_content_units(new_meta,
                                    "YELL",
                                    force = FALSE)
-    geo_desc <- arcticdatautils::eml_get_simple(new_meta2, "geographicDescription")
+    geo_desc <- get_eml_simple(new_meta2, "geographicDescription")
     expect_true("NPS Content Unit Link: YELL" %in% geo_desc)
   })
 })


### PR DESCRIPTION
replaces calls to arcticdatautils eml_get_simple with EMLeditor::get_eml_simple (which is functionally identical) and removes arcticdatautils from remotes and suggests.

closes #166 