### PR TITLE
Read column types in using the domain type rather than storage type

### DIFF
--- a/R/getEMLfunctions.R
+++ b/R/getEMLfunctions.R
@@ -858,10 +858,10 @@ get_attribute_tables <- function(eml_object) {
     # add a class column
     # rename dttm format column
     attr_temp_cleaned <- attr_temp_cleaned %>%
-      dplyr::mutate(class = dplyr::case_when(storageType %in% c("float", "double", "long", "int") ~ "numeric",
+      dplyr::mutate(class = dplyr::case_when(domain == "numericDomain" ~ "numeric",
                                              (storageType == "string" & domain == "textDomain") ~ "character",
                                              (storageType == "string" & domain == "enumeratedDomain") ~ "categorical",
-                                             storageType == "date" ~ "Date",
+                                             domain == "dateTimeDomain" ~ "Date",
                                              TRUE ~ "")) %>%
       dplyr::rename(dateTimeFormatString = formatString) %>%
       dplyr::select(attributeName, attributeDefinition, class, unit, dateTimeFormatString, missingValueCode, missingValueCodeExplanation)


### PR DESCRIPTION
A small change to cover more column types when getting attribute tables. EML::get attributes returns many different storage types (integer, float, date, dateTime), but only a few domains, so it makes more sense to distinguish between numeric/date/character/categorical attributes using the domain.